### PR TITLE
Don't expose debug modules in general cofy api init

### DIFF
--- a/src/cofy/api/__init__.py
+++ b/src/cofy/api/__init__.py
@@ -1,14 +1,10 @@
 from .cofy_api import CofyAPI
-from .debug_middleware import DebugMiddleware
-from .debug_router import DebugRouter
 from .docs_router import DocsRouter
 from .module import Module
 from .token_auth import TokenInfo, token_verifier
 
 __all__ = [
     "CofyAPI",
-    "DebugMiddleware",
-    "DebugRouter",
     "DocsRouter",
     "Module",
     "TokenInfo",


### PR DESCRIPTION
This pull request fixes a bug where the package can't be imported without debug dependencies being installed.
