### PR TITLE
Add support for dynamic directive boundaries

### DIFF
--- a/src/cofy/modules/directive/__init__.py
+++ b/src/cofy/modules/directive/__init__.py
@@ -1,5 +1,6 @@
 from .formats.directive import DirectiveFormat
 from .module import DirectiveModule
 from .sources.directive_source import DirectiveSource
+from .sources.dynamic_boundary_directive_source import DynamicBoundaryDirectiveSource
 
-__all__ = ["DirectiveModule", "DirectiveSource", "DirectiveFormat"]
+__all__ = ["DirectiveModule", "DirectiveSource", "DirectiveFormat", "DynamicBoundaryDirectiveSource"]

--- a/src/cofy/modules/directive/sources/dynamic_boundary_directive_source.py
+++ b/src/cofy/modules/directive/sources/dynamic_boundary_directive_source.py
@@ -1,0 +1,75 @@
+import asyncio
+import datetime as dt
+
+import narwhals as nw
+
+from cofy.modules.timeseries import ISODuration, Timeseries, TimeseriesSource
+
+from ..formats.directive import DIRECTIVE_STEPS
+
+BOUNDARY_COLUMNS = ("b0", "b1", "b2", "b3")
+
+
+class DynamicBoundaryDirectiveSource(TimeseriesSource):
+    def __init__(
+        self,
+        signal_source: TimeseriesSource,
+        boundary_source: TimeseriesSource,
+        reverse: bool = False,
+    ):
+        """A TimeseriesSource that maps numeric values to directive steps using per-timestamp dynamic boundaries.
+
+        Args:
+            signal_source: The underlying TimeseriesSource providing the numeric signal values.
+            boundary_source: A TimeseriesSource whose dataframe contains a 'timestamp' column and
+                four boundary columns ('b0', 'b1', 'b2', 'b3') in ascending order, defining the
+                thresholds between directive steps at each timestamp.
+            reverse: If True, the mapping of values to directive steps will be reversed (i.e.,
+                higher values will correspond to more negative steps).
+        """
+        self.signal_source = signal_source
+        self.boundary_source = boundary_source
+        self.reverse = reverse
+
+    async def fetch_timeseries(
+        self,
+        start: dt.datetime,
+        end: dt.datetime,
+        resolution: ISODuration,
+        **kwargs,
+    ) -> Timeseries:
+        signal_ts, boundary_ts = await asyncio.gather(
+            self.signal_source.fetch_timeseries(start, end, resolution, **kwargs),
+            self.boundary_source.fetch_timeseries(start, end, resolution, **kwargs),
+        )
+
+        combined = signal_ts.frame.join(boundary_ts.frame, on="timestamp", how="inner")
+
+        steps = DIRECTIVE_STEPS if not self.reverse else list(reversed(DIRECTIVE_STEPS))
+
+        expr = nw.lit(steps[0])
+        for col_name, step in zip(BOUNDARY_COLUMNS, steps[1:], strict=True):
+            expr = nw.when(nw.col("value") > nw.col(col_name)).then(nw.lit(step)).otherwise(expr)
+
+        combined = combined.with_columns(value=expr).select(["timestamp", "value"])
+
+        result = Timeseries(frame=combined, metadata=signal_ts.metadata)
+        result.metadata["unit"] = "directive"
+        return result
+
+    @property
+    def supported_resolutions(self) -> list[str]:
+        # The supported resolutions are the intersection of the signal source and boundary source resolutions
+        # if one returns an empty list, it means it supports all resolutions, so we can ignore it in the intersection
+        signal_resolutions = set(self.signal_source.supported_resolutions)
+        boundary_resolutions = set(self.boundary_source.supported_resolutions)
+        if not signal_resolutions:
+            return list(boundary_resolutions)
+        if not boundary_resolutions:
+            return list(signal_resolutions)
+        return list(signal_resolutions & boundary_resolutions)
+
+    @property
+    def extra_args(self) -> dict:
+        # The extra args are the union of the signal source and boundary source extra args, with signal source taking precedence in case of conflicts
+        return {**self.boundary_source.extra_args, **self.signal_source.extra_args}

--- a/src/cofy/modules/directive/sources/dynamic_boundary_directive_source.py
+++ b/src/cofy/modules/directive/sources/dynamic_boundary_directive_source.py
@@ -43,6 +43,12 @@ class DynamicBoundaryDirectiveSource(TimeseriesSource):
             self.boundary_source.fetch_timeseries(start, end, resolution, **kwargs),
         )
 
+        invalid = boundary_ts.frame.filter(
+            (nw.col("b0") > nw.col("b1")) | (nw.col("b1") > nw.col("b2")) | (nw.col("b2") > nw.col("b3"))
+        )
+        if len(invalid) > 0:
+            raise ValueError("Boundary columns must be in ascending order (b0 ≤ b1 ≤ b2 ≤ b3). ")
+
         combined = signal_ts.frame.join(boundary_ts.frame, on="timestamp", how="inner")
 
         steps = DIRECTIVE_STEPS if not self.reverse else list(reversed(DIRECTIVE_STEPS))

--- a/tests/cofy/modules/directive/sources/dynamic_boundary_directive_source_test.py
+++ b/tests/cofy/modules/directive/sources/dynamic_boundary_directive_source_test.py
@@ -96,6 +96,24 @@ async def test_fetch_timeseries_reversed():
 
 
 @pytest.mark.asyncio
+async def test_raises_value_error_when_boundaries_are_not_ascending():
+    boundary_source = DummyBoundarySource(
+        boundaries=[
+            (5, 15, 25, 35),  # valid
+            (5, 25, 15, 35),  # b1 > b2: invalid
+        ]
+    )
+    source = DynamicBoundaryDirectiveSource(DummyTimeseriesSource(), boundary_source)
+
+    with pytest.raises(ValueError, match="ascending order"):
+        await source.fetch_timeseries(
+            dt.datetime(2026, 1, 1, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC),
+            dt.timedelta(hours=1),
+        )
+
+
+@pytest.mark.asyncio
 async def test_missing_timestamp_on_boundary_side_is_excluded():
     # If a timestamp is missing in boundary_source it should not appear in the result
     class SparseBoundarySource(TimeseriesSource):

--- a/tests/cofy/modules/directive/sources/dynamic_boundary_directive_source_test.py
+++ b/tests/cofy/modules/directive/sources/dynamic_boundary_directive_source_test.py
@@ -1,0 +1,194 @@
+import datetime as dt
+
+import pandas as pd
+import pytest
+
+from cofy.modules.directive import DynamicBoundaryDirectiveSource
+from cofy.modules.timeseries import ISODuration, Timeseries, TimeseriesSource
+
+from ...timeseries.dummy_source import DummyTimeseriesSource
+
+
+class DummyBoundarySource(TimeseriesSource):
+    """Returns a frame with timestamp and four boundary columns b0–b3."""
+
+    def __init__(self, boundaries: list[tuple[float, float, float, float]]):
+        self._boundaries = boundaries
+
+    async def fetch_timeseries(
+        self,
+        start: dt.datetime,
+        end: dt.datetime,
+        resolution: ISODuration = dt.timedelta(hours=1),
+        **kwargs,
+    ) -> Timeseries:
+        data = []
+        i = 0
+        while start + i * resolution < end:
+            b0, b1, b2, b3 = self._boundaries[i]
+            data.append({"timestamp": start + i * resolution, "b0": b0, "b1": b1, "b2": b2, "b3": b3})
+            i += 1
+        return Timeseries(frame=pd.DataFrame(data), metadata={})
+
+
+@pytest.mark.asyncio
+async def test_fetch_timeseries_applies_dynamic_boundaries():
+    # DummyTimeseriesSource emits values 0, 10, 20, 30, 40, 50, 60 for 7 hours
+    boundary_source = DummyBoundarySource(
+        boundaries=[
+            (5, 15, 25, 35),  # t0: value=0  -> "--"
+            (5, 15, 25, 35),  # t1: value=10 -> "-"
+            (5, 15, 25, 35),  # t2: value=20 -> "0"
+            (5, 15, 25, 35),  # t3: value=30 -> "+"
+            (5, 15, 25, 35),  # t4: value=40 -> "++"
+            (5, 15, 25, 35),  # t5: value=50 -> "++"
+            (5, 15, 25, 35),  # t6: value=60 -> "++"
+        ]
+    )
+    source = DynamicBoundaryDirectiveSource(DummyTimeseriesSource(), boundary_source)
+
+    result = await source.fetch_timeseries(
+        dt.datetime(2026, 1, 1, 0, 0, tzinfo=dt.UTC),
+        dt.datetime(2026, 1, 1, 7, 0, tzinfo=dt.UTC),
+        dt.timedelta(hours=1),
+    )
+
+    assert [row["value"] for row in result.to_arr()] == ["--", "-", "0", "+", "++", "++", "++"]
+    assert result.metadata["unit"] == "directive"
+
+
+@pytest.mark.asyncio
+async def test_fetch_timeseries_uses_per_timestamp_boundaries():
+    # Boundaries shift so the same signal value maps to a different step at each timestamp
+    # DummyTimeseriesSource emits value=0, 10, 20 for 3 hours
+    boundary_source = DummyBoundarySource(
+        boundaries=[
+            (-10, 5, 15, 25),  # t0: value=0  -> "-"  (0 > -10 but not > 5)
+            (-10, -5, 5, 15),  # t1: value=10 -> "+" (10 > 15? no -> "+"; 10 > 5 -> "+")
+            (25, 35, 45, 55),  # t2: value=20 -> "--" (20 < 25)
+        ]
+    )
+    source = DynamicBoundaryDirectiveSource(DummyTimeseriesSource(), boundary_source)
+
+    result = await source.fetch_timeseries(
+        dt.datetime(2026, 1, 1, 0, 0, tzinfo=dt.UTC),
+        dt.datetime(2026, 1, 1, 3, 0, tzinfo=dt.UTC),
+        dt.timedelta(hours=1),
+    )
+
+    assert [row["value"] for row in result.to_arr()] == ["-", "+", "--"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_timeseries_reversed():
+    # With reverse=True, higher values map to more negative steps
+    # DummyTimeseriesSource: values 0, 10, 20, 30, 40
+    boundary_source = DummyBoundarySource(boundaries=[(5, 15, 25, 35)] * 5)
+    source = DynamicBoundaryDirectiveSource(DummyTimeseriesSource(), boundary_source, reverse=True)
+
+    result = await source.fetch_timeseries(
+        dt.datetime(2026, 1, 1, 0, 0, tzinfo=dt.UTC),
+        dt.datetime(2026, 1, 1, 5, 0, tzinfo=dt.UTC),
+        dt.timedelta(hours=1),
+    )
+
+    assert [row["value"] for row in result.to_arr()] == ["++", "+", "0", "-", "--"]
+
+
+@pytest.mark.asyncio
+async def test_missing_timestamp_on_boundary_side_is_excluded():
+    # If a timestamp is missing in boundary_source it should not appear in the result
+    class SparseBoundarySource(TimeseriesSource):
+        async def fetch_timeseries(self, start, end, resolution=dt.timedelta(hours=1), **kwargs):
+            # Only returns rows for t0 and t2, skipping t1
+            data = [
+                {"timestamp": start, "b0": 5.0, "b1": 15.0, "b2": 25.0, "b3": 35.0},
+                {"timestamp": start + 2 * resolution, "b0": 5.0, "b1": 15.0, "b2": 25.0, "b3": 35.0},
+            ]
+            return Timeseries(frame=pd.DataFrame(data), metadata={})
+
+    source = DynamicBoundaryDirectiveSource(DummyTimeseriesSource(), SparseBoundarySource())
+
+    result = await source.fetch_timeseries(
+        dt.datetime(2026, 1, 1, 0, 0, tzinfo=dt.UTC),
+        dt.datetime(2026, 1, 1, 3, 0, tzinfo=dt.UTC),
+        dt.timedelta(hours=1),
+    )
+
+    timestamps = [row["timestamp"] for row in result.to_arr()]
+    assert len(timestamps) == 2
+    assert dt.datetime(2026, 1, 1, 1, 0, tzinfo=dt.UTC) not in timestamps
+
+
+class ConfigurableSource(TimeseriesSource):
+    def __init__(self, resolutions: list[str] | None = None, extra_args: dict | None = None):
+        self._resolutions = resolutions or []
+        self._extra_args = extra_args or {}
+
+    async def fetch_timeseries(self, start, end, resolution, **kwargs):
+        raise NotImplementedError
+
+    @property
+    def supported_resolutions(self):
+        return self._resolutions
+
+    @property
+    def extra_args(self):
+        return self._extra_args
+
+
+def test_supported_resolutions_returns_intersection_of_both_sources():
+    signal = ConfigurableSource(resolutions=["PT15M", "PT1H"])
+    boundary = ConfigurableSource(resolutions=["PT1H", "P1D"])
+    source = DynamicBoundaryDirectiveSource(signal, boundary)
+
+    assert set(source.supported_resolutions) == {"PT1H"}
+
+
+def test_supported_resolutions_signal_empty_means_all_returns_boundary_list():
+    signal = ConfigurableSource(resolutions=[])
+    boundary = ConfigurableSource(resolutions=["PT15M", "P1D"])
+    source = DynamicBoundaryDirectiveSource(signal, boundary)
+
+    assert set(source.supported_resolutions) == {"PT15M", "P1D"}
+
+
+def test_supported_resolutions_boundary_empty_means_all_returns_signal_list():
+    signal = ConfigurableSource(resolutions=["PT15M", "P1D"])
+    boundary = ConfigurableSource(resolutions=[])
+    source = DynamicBoundaryDirectiveSource(signal, boundary)
+
+    assert set(source.supported_resolutions) == {"PT15M", "P1D"}
+
+
+def test_supported_resolutions_both_empty_returns_empty():
+    source = DynamicBoundaryDirectiveSource(
+        ConfigurableSource(resolutions=[]),
+        ConfigurableSource(resolutions=[]),
+    )
+
+    assert source.supported_resolutions == []
+
+
+def test_extra_args_are_union_with_signal_taking_precedence():
+    signal = ConfigurableSource(extra_args={"key": str, "shared": int})
+    boundary = ConfigurableSource(extra_args={"other": float, "shared": str})
+    source = DynamicBoundaryDirectiveSource(signal, boundary)
+
+    assert source.extra_args == {"key": str, "other": float, "shared": int}
+
+
+def test_extra_args_signal_only():
+    signal = ConfigurableSource(extra_args={"a": str})
+    boundary = ConfigurableSource(extra_args={})
+    source = DynamicBoundaryDirectiveSource(signal, boundary)
+
+    assert source.extra_args == {"a": str}
+
+
+def test_extra_args_boundary_only():
+    signal = ConfigurableSource(extra_args={})
+    boundary = ConfigurableSource(extra_args={"b": float})
+    source = DynamicBoundaryDirectiveSource(signal, boundary)
+
+    assert source.extra_args == {"b": float}


### PR DESCRIPTION
This pull request adds support for dynamic boundaries.

You can now create a timeseries source for boundaries as well as the signal. These are then combined to create the `--,-,0,+,++` directive signal.

See EPV usecase: https://github.com/EnergieID/cofy-api-epv/issues/13
