### PR TITLE
[Breaking] Upgrade energy-cost from 0.6.1 to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ tariff = [
 ]
 billing = [
     "cofy-api[timeseries]",
-    "energy-cost>=0.6.1",
+    "energy-cost>=0.7.0",
     "pandas>=3.0.0"
 ]
 production = [
@@ -39,7 +39,7 @@ production = [
     "requests>=2.32.0",
 ]
 members = [
-    "energy-cost>=0.6.1",
+    "energy-cost>=0.7.0",
 ]
 directive = [
     "cofy-api[timeseries]",

--- a/src/cofy/modules/billing/models/billing_request.py
+++ b/src/cofy/modules/billing/models/billing_request.py
@@ -44,14 +44,14 @@ class TimeseriesInfo(BaseModel):
 
 class MeterInfo(BaseModel):
     type: MeterType = Field(default=MeterType.SINGLE_RATE, examples=["single_rate"])
-    power: TimeseriesInfo
+    measurements: TimeseriesInfo
     capacity: TimeseriesInfo | None = None
 
     def to_meter(self, direction: PowerDirection) -> Meter:
         return Meter(
             direction=direction,
             type=self.type,
-            power=self.power.to_timeseries(),
+            measurements=self.measurements.to_timeseries(),
             capacity=self.capacity.to_timeseries() if self.capacity is not None else None,
         )
 
@@ -67,7 +67,7 @@ class BillingRequest(BaseModel):
                     "resolution": "P1M",
                     "consumption": {
                         "type": "single_rate",
-                        "power": {
+                        "measurements": {
                             "values": [
                                 {"timestamp": "2024-01-01T00:00:00+01:00", "value": 5.5},
                                 {"timestamp": "2024-01-01T00:15:00+01:00", "value": 7.3},

--- a/tests/cofy/modules/billing/module_test.py
+++ b/tests/cofy/modules/billing/module_test.py
@@ -26,7 +26,7 @@ _START = "2024-01-01T00:00:00+00:00"
 _END = "2024-02-01T00:00:00+00:00"
 _METER: dict = {
     "type": "single_rate",
-    "power": {
+    "measurements": {
         "values": [
             {"timestamp": _START, "value": 150.5},
             {"timestamp": "2024-01-15T00:00:00+00:00", "value": 75.3},
@@ -48,7 +48,7 @@ _DST_BODY = {
     # end is 2024-03-30T22:04:00Z — BEFORE start (2024-03-30T23:00:00Z) in UTC
     "end": "2024-03-31T00:04:00+02:00",
     "consumption": {
-        "power": {
+        "measurements": {
             "values": [
                 {"timestamp": "2024-03-31T01:45:00+01:00", "value": 150.5},
                 {"timestamp": "2024-03-31T03:00:00+02:00", "value": 75.3},
@@ -135,7 +135,7 @@ class TestBillingEndpoint:
         assert response.status_code == 422
 
     def test_post_returns_422_for_empty_meter_data(self):
-        body = {**_BODY, "consumption": {"type": "single_rate", "power": {"values": [], "resolution": "PT15M"}}}
+        body = {**_BODY, "consumption": {"type": "single_rate", "measurements": {"values": [], "resolution": "PT15M"}}}
         response = self.client.post(self.module.prefix, json=body)
         assert response.status_code == 422
 
@@ -144,7 +144,7 @@ class TestBillingEndpoint:
             **_BODY,
             "consumption": {
                 "type": "single_rate",
-                "power": {"values": [{"timestamp": _START, "value": 100.0}], "resolution": "PT15M"},
+                "measurements": {"values": [{"timestamp": _START, "value": 100.0}], "resolution": "PT15M"},
             },
         }
         response = self.client.post(self.module.prefix, json=body)

--- a/uv.lock
+++ b/uv.lock
@@ -221,8 +221,8 @@ requires-dist = [
     { name = "cofy-api", extras = ["timeseries"], marker = "extra == 'production'" },
     { name = "cofy-api", extras = ["timeseries"], marker = "extra == 'tariff'" },
     { name = "cofy-api", extras = ["timeseries", "tariff", "members", "production", "directive", "billing", "debug"], marker = "extra == 'all'" },
-    { name = "energy-cost", marker = "extra == 'billing'", specifier = ">=0.6.1" },
-    { name = "energy-cost", marker = "extra == 'members'", specifier = ">=0.6.1" },
+    { name = "energy-cost", marker = "extra == 'billing'", specifier = ">=0.7.0" },
+    { name = "energy-cost", marker = "extra == 'members'", specifier = ">=0.7.0" },
     { name = "energy-cost", marker = "extra == 'tariff'", specifier = ">=0.6.1" },
     { name = "entsoe-py", marker = "extra == 'tariff'", specifier = ">=0.7.10" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.128.0" },
@@ -375,7 +375,7 @@ wheels = [
 
 [[package]]
 name = "energy-cost"
-version = "0.6.1"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "entsoe-py" },
@@ -384,9 +384,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/f2/27f8b454f860b400d5e6c94e83686a7bb470543e6fb235ea021704f4824c/energy_cost-0.6.1.tar.gz", hash = "sha256:3c9d32ceff461d841bdbed10bf093cf6626d8a3e060b585336a6b42f00edea4f", size = 61362, upload-time = "2026-06-01T13:52:21.389Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/a6/6b4edd5dd008aa57406153a62abbc9e2d41a4e392340c60139dd2eccec49/energy_cost-0.7.0.tar.gz", hash = "sha256:4cc1823b99a06714a772e04f1496c312ff8023ad1e2bedf667746b9a0f6eff7a", size = 65864, upload-time = "2026-06-15T07:51:55.406Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/97/42b89c8517f8e5bfd437c433b02076e367725dae9292dca261a3604a83a6/energy_cost-0.6.1-py3-none-any.whl", hash = "sha256:50238463e1617fb70e508bea5d711ae715e869a302ea34c6d32bde5164846db0", size = 61365, upload-time = "2026-06-01T13:52:22.367Z" },
+    { url = "https://files.pythonhosted.org/packages/03/2b/60d47756138766a806649b265a5a54a206721bf7b7d5ca353e0a09c54f43/energy_cost-0.7.0-py3-none-any.whl", hash = "sha256:4a7bacdce99a7610665ea9959f75dfb3823092292f178454805e1541f82cd79b", size = 61753, upload-time = "2026-06-15T07:51:54.418Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request upgrades energy-cost  to version [0.7.0](https://github.com/EnergieID/energy-cost/releases/tag/v0.7.0)

This includes a Breaking change, renaming `power` to `measurements` in our api.