### PR TITLE
Add management api for cofy cloud configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,6 +20,22 @@
                 "PYTHONPYCACHEPREFIX": "${workspaceFolder}/.pycache"
             },
             "justMyCode": false
+        },
+        {
+            "name": "Python Debugger: Management API",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "cofy.management.main:app",
+                "--reload"
+            ],
+            "jinja": true,
+            "envFile": "${workspaceFolder}/.env.local",
+            "env": {
+                "PYTHONPYCACHEPREFIX": "${workspaceFolder}/.pycache"
+            },
+            "justMyCode": false
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,5 @@
     "python.testing.pytestArgs": [
         "tests", "--import-mode=importlib"
     ],
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,8 @@ envfile = ".env.local"
 [tool.poe.tasks.from_settings]
 cmd = "fastapi dev demo/from_settings.py"
 envfile = ".env.local"
+[tool.poe.tasks.management]
+cmd = "uvicorn cofy.management.main:app --reload"
 [tool.poe.tasks.prod]
 shell = """
 docker build -t cofy-api .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ directive = [
 debug = [
     "yappi>=1.7.6",
 ]
+management = [
+    "cofy-api[timeseries,tariff,members,production,directive,billing,debug]",
+    "PyYAML>=6.0.0",
+]
 
 # Convenience extras
 all = ["cofy-api[timeseries,tariff,members,production,directive,billing,debug]"]

--- a/specs/Directory structure.md
+++ b/specs/Directory structure.md
@@ -1,24 +1,33 @@
 
 ```sh
 src/
-    cofy/                           # Core framework (installable package)
+    cofy/                       # Core framework (installable package)
         __init__.py                 # Public API: CofyAPI, Module
         api/
             cofy_api.py                 # Main app class, handles settings and module registration
             module.py                   # Base Module class (abstract APIRouter)
             docs_router.py              # OpenAPI / docs endpoints
             token_auth.py               # Token-based authentication
+            from_settings_mixin.py      # Mixin for creating objects from settings
         modules/                    # Grouping folder for domain modules (namespace package)
             <module_name>/
-                __init__.py         # Public API for this module (re-exports)
-                module.py           # Main module class: settings, route registration
-                model.py            # Pydantic model(s) for the external API
-                source.py           # Source interface and/or default implementation
-                sources/            # Optional: data source implementations (DB, API, …)
-                formats/            # Optional: formatters for the api output
-                tasks/              # Optional: background tasks related to this module
-            timeseries/             # Generic timeseries module (base for tariff, etc.)
-demo/                               # Dev demo application (not part of installable package)
+                __init__.py             # Public API for this module (re-exports)
+                module.py               # Main module class: settings, route registration
+                model.py                # Pydantic model(s) for the external API
+                source.py               # Source interface and/or default implementation
+                sources/                # Optional: data source implementations (DB, API, …)
+                formats/                # Optional: formatters for the api output
+                tasks/                  # Optional: background tasks related to this module
+            timeseries/                 # Generic timeseries module (base for tariff, etc.)
+        management/                 # Api to manage one or more cofy configurations
+            api/                        # Management API endpoints
+                modules.py                     # Endpoints for managing modules of a comunity
+            main.py                     # Runs the management api and multiple cofy instances based on the managed configs
+            persitance/                 # Persistence backends for the management api
+                base.py                     # Base class for persistence backends
+                file.py                     # File-based persistence backend
+            
+demo/                           # Dev demo application (not part of installable package)
     main.py                         # Example app tying everything together
     data/                           # Example data for the demo app
 tests/                              # Mirrors src/ structure

--- a/src/cofy/api/cofy_api.py
+++ b/src/cofy/api/cofy_api.py
@@ -27,7 +27,7 @@ class CofyAPISettings(BaseSettingsModel):
     description: str = DEFAULT_ARGS["description"]
     debug_mode: bool = False
     debug_dir: Path | None = None
-    modules: list[ModuleSettings] | None = None
+    modules: list[ModuleSettings] = []
     auth: AuthSettings | None = None
 
 

--- a/src/cofy/api/from_settings_mixin.py
+++ b/src/cofy/api/from_settings_mixin.py
@@ -10,8 +10,6 @@ def _resolve(value: Any) -> Any:
     """Recursively convert any BaseSettingsModel instances to their actual objects."""
     if isinstance(value, BaseSettingsModel):
         return value.convert()
-    if hasattr(value, "get_secret_value") and callable(value.get_secret_value):
-        return value.get_secret_value()
     if isinstance(value, list):
         return [_resolve(v) for v in value]
     if isinstance(value, dict):

--- a/src/cofy/api/from_settings_mixin.py
+++ b/src/cofy/api/from_settings_mixin.py
@@ -47,15 +47,10 @@ class BaseSettingsModel(BaseModel):
         Nested `BaseSettingsModel`-typed fields are expanded to their own discriminated unions
         """
         registry = getattr(cls._model, "_registry", {})
-        if not registry:
-            return cls
-
-        response_cache: dict[type[BaseSettingsModel], type[BaseSettingsModel]] = {}
-        stack: set[type[BaseSettingsModel]] = set()
 
         tagged_models: list[Any] = []
         for key, model in registry.items():
-            resolved_model = _build_recursive_response_model(model, response_cache, stack)
+            resolved_model = _build_recursive_response_model(model)
             tagged_models.append(Annotated[resolved_model, Tag(key)])  # ty: ignore[invalid-type-form]
 
         union = _build_union_type(tagged_models)
@@ -69,61 +64,35 @@ def _discriminator_type(value: Any) -> Any:
 
 
 def _build_union_type(models: list[Any]) -> Any:
-    if not models:
-        return Any
-
     union = models[0]
     for model in models[1:]:
         union = union | model
     return union
 
 
-def _build_recursive_response_model(
-    model: type[BaseSettingsModel],
-    cache: dict[type[BaseSettingsModel], type[BaseSettingsModel]],
-    stack: set[type[BaseSettingsModel]],
-) -> type[BaseSettingsModel]:
-    if model in cache:
-        return cache[model]
-
-    if model in stack:
-        # Break circular references by falling back to the current model.
-        return model
-
-    stack.add(model)
+def _build_recursive_response_model(model: type[BaseSettingsModel]) -> type[BaseSettingsModel]:
     overrides: dict[str, tuple[Any, Any]] = {}
 
     for field_name, field in model.model_fields.items():
-        new_annotation = _transform_annotation(field.annotation, cache, stack)
+        new_annotation = _transform_annotation(field.annotation)
         if new_annotation is field.annotation:
             continue
 
         default = ... if field.is_required() else field.default
         overrides[field_name] = (new_annotation, default)
-        default = ... if field.is_required() else field.default
-        overrides[field_name] = (new_annotation, default)
-
-    stack.remove(model)
 
     if not overrides:
-        cache[model] = model
         return model
 
-    recursive_model = create_model(
+    return create_model(
         f"{model.__name__}Response",
         __base__=model,
         __module__=model.__module__,
         **overrides,
     )  # ty: ignore[no-matching-overload]
-    cache[model] = recursive_model
-    return recursive_model
 
 
-def _transform_annotation(
-    annotation: Any,
-    cache: dict[type[BaseSettingsModel], type[BaseSettingsModel]],
-    stack: set[type[BaseSettingsModel]],
-) -> Any:
+def _transform_annotation(annotation: Any) -> Any:
     if isinstance(annotation, type) and issubclass(annotation, BaseSettingsModel):
         model_cls = getattr(annotation, "_model", None)
         if model_cls is None:
@@ -135,16 +104,8 @@ def _transform_annotation(
         return annotation
 
     args = get_args(annotation)
-    if not args:
-        return annotation
 
-    if origin is Annotated:
-        transformed = _transform_annotation(args[0], cache, stack)
-        if transformed is args[0]:
-            return annotation
-        return Annotated[transformed, *args[1:]]
-
-    transformed_args = tuple(_transform_annotation(arg, cache, stack) for arg in args)
+    transformed_args = tuple(_transform_annotation(arg) for arg in args)
     if transformed_args == args:
         return annotation
 
@@ -154,12 +115,9 @@ def _transform_annotation(
             union = union | arg
         return union
 
-    try:
-        if len(transformed_args) == 1:
-            return origin[transformed_args[0]]
-        return origin[transformed_args]
-    except Exception:
-        return annotation
+    if len(transformed_args) == 1:
+        return origin[transformed_args[0]]
+    return origin[transformed_args]
 
 
 class FromSettingsMixin:

--- a/src/cofy/api/from_settings_mixin.py
+++ b/src/cofy/api/from_settings_mixin.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Annotated, Any, ClassVar
+from types import UnionType
+from typing import Annotated, Any, ClassVar, Union, get_args, get_origin
 
-from pydantic import BaseModel, Discriminator, Tag, model_validator
+from pydantic import BaseModel, Discriminator, Tag, create_model, model_validator
 
 
 def _resolve(value: Any) -> Any:
@@ -43,13 +44,124 @@ class BaseSettingsModel(BaseModel):
         return self._model(**kwargs)
 
     @classmethod
-    def union_type(cls):
-        """Return a union type of registered settings models."""
+    def union_type(cls) -> Any:
+        """Return a discriminated union type of registered settings models.
+        Nested `BaseSettingsModel`-typed fields are expanded to their own discriminated unions
+        """
         registry = getattr(cls._model, "_registry", {})
-        models = tuple(Annotated[model, Tag(key)] for key, model in registry.items())
-        return Annotated[
-            models, Discriminator(lambda x: x.get("type") if isinstance(x, dict) else getattr(x, "type", None))  # ty: ignore[invalid-type-form]
-        ]  # noqa: UP007
+        if not registry:
+            return cls
+
+        response_cache: dict[type[BaseSettingsModel], type[BaseSettingsModel]] = {}
+        stack: set[type[BaseSettingsModel]] = set()
+
+        tagged_models: list[Any] = []
+        for key, model in registry.items():
+            resolved_model = _build_recursive_response_model(model, response_cache, stack)
+            tagged_models.append(Annotated[resolved_model, Tag(key)])  # ty: ignore[invalid-type-form]
+
+        union = _build_union_type(tagged_models)
+        return Annotated[union, Discriminator(_discriminator_type)]
+
+
+def _discriminator_type(value: Any) -> Any:
+    if isinstance(value, dict):
+        return value.get("type")
+    return getattr(value, "type", None)
+
+
+def _build_union_type(models: list[Any]) -> Any:
+    if not models:
+        return Any
+
+    union = models[0]
+    for model in models[1:]:
+        union = union | model
+    return union
+
+
+def _build_recursive_response_model(
+    model: type[BaseSettingsModel],
+    cache: dict[type[BaseSettingsModel], type[BaseSettingsModel]],
+    stack: set[type[BaseSettingsModel]],
+) -> type[BaseSettingsModel]:
+    if model in cache:
+        return cache[model]
+
+    if model in stack:
+        # Break circular references by falling back to the current model.
+        return model
+
+    stack.add(model)
+    overrides: dict[str, tuple[Any, Any]] = {}
+
+    for field_name, field in model.model_fields.items():
+        new_annotation = _transform_annotation(field.annotation, cache, stack)
+        if new_annotation is field.annotation:
+            continue
+
+        default = ... if field.is_required() else field.default
+        overrides[field_name] = (new_annotation, default)
+        default = ... if field.is_required() else field.default
+        overrides[field_name] = (new_annotation, default)
+
+    stack.remove(model)
+
+    if not overrides:
+        cache[model] = model
+        return model
+
+    recursive_model = create_model(
+        f"{model.__name__}Response",
+        __base__=model,
+        __module__=model.__module__,
+        **overrides,
+    )  # ty: ignore[no-matching-overload]
+    cache[model] = recursive_model
+    return recursive_model
+
+
+def _transform_annotation(
+    annotation: Any,
+    cache: dict[type[BaseSettingsModel], type[BaseSettingsModel]],
+    stack: set[type[BaseSettingsModel]],
+) -> Any:
+    if isinstance(annotation, type) and issubclass(annotation, BaseSettingsModel):
+        model_cls = getattr(annotation, "_model", None)
+        if model_cls is None:
+            return annotation
+        return annotation.union_type()
+
+    origin = get_origin(annotation)
+    if origin is None:
+        return annotation
+
+    args = get_args(annotation)
+    if not args:
+        return annotation
+
+    if origin is Annotated:
+        transformed = _transform_annotation(args[0], cache, stack)
+        if transformed is args[0]:
+            return annotation
+        return Annotated[transformed, *args[1:]]
+
+    transformed_args = tuple(_transform_annotation(arg, cache, stack) for arg in args)
+    if transformed_args == args:
+        return annotation
+
+    if origin in (Union, UnionType):
+        union = transformed_args[0]
+        for arg in transformed_args[1:]:
+            union = union | arg
+        return union
+
+    try:
+        if len(transformed_args) == 1:
+            return origin[transformed_args[0]]
+        return origin[transformed_args]
+    except Exception:
+        return annotation
 
 
 class FromSettingsMixin:

--- a/src/cofy/api/from_settings_mixin.py
+++ b/src/cofy/api/from_settings_mixin.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, ClassVar
+from typing import Annotated, Any, ClassVar
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Discriminator, Tag, model_validator
 
 
 def _resolve(value: Any) -> Any:
@@ -19,7 +19,6 @@ def _resolve(value: Any) -> Any:
 
 
 class BaseSettingsModel(BaseModel):
-    type: str = Field(..., description="Registry discriminator.")
     _model: ClassVar[Any]  # wired automatically on registration
 
     @model_validator(mode="wrap")
@@ -42,6 +41,15 @@ class BaseSettingsModel(BaseModel):
     def convert(self) -> Any:
         kwargs = {name: _resolve(getattr(self, name)) for name in self.__class__.model_fields if name != "type"}
         return self._model(**kwargs)
+
+    @classmethod
+    def union_type(cls):
+        """Return a union type of registered settings models."""
+        registry = getattr(cls._model, "_registry", {})
+        models = tuple(Annotated[model, Tag(key)] for key, model in registry.items())
+        return Annotated[
+            models, Discriminator(lambda x: x.get("type") if isinstance(x, dict) else getattr(x, "type", None))  # ty: ignore[invalid-type-form]
+        ]  # noqa: UP007
 
 
 class FromSettingsMixin:

--- a/src/cofy/api/token_auth.py
+++ b/src/cofy/api/token_auth.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import APIKeyHeader, APIKeyQuery
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel
 from starlette.status import HTTP_401_UNAUTHORIZED
 
 from .from_settings_mixin import BaseSettingsModel, FromSettingsMixin
@@ -34,7 +34,7 @@ class TokenInfo(BaseModel):
 
 class TokenAuthSettings(AuthSettings):
     type: str = "token"
-    tokens: dict[SecretStr, TokenInfo] = {}
+    tokens: dict[str, TokenInfo] = {}
 
 
 class TokenAuth(Auth, settings=TokenAuthSettings):

--- a/src/cofy/management/__init__.py
+++ b/src/cofy/management/__init__.py
@@ -1,0 +1,3 @@
+from .main import app
+
+__all__ = ["app"]

--- a/src/cofy/management/api/__init__.py
+++ b/src/cofy/management/api/__init__.py
@@ -1,0 +1,3 @@
+from .modules import ModulesRouter
+
+__all__ = ["ModulesRouter"]

--- a/src/cofy/management/api/modules.py
+++ b/src/cofy/management/api/modules.py
@@ -5,7 +5,10 @@ from typing import Annotated
 from fastapi import APIRouter, Body, Path
 
 from cofy.api.module import ModuleSettings
-from cofy.management.persitance.modules import ModulesPersistence
+
+from ..persitance.modules import ModulesPersistence
+
+MODULE_SETTINGS_TYPE = ModuleSettings.union_type()
 
 
 class ModulesRouter:
@@ -25,7 +28,7 @@ class ModulesRouter:
     def all(
         self,
         slug: Annotated[str, Path(description="Community slug, currently one of: foo, bar")],
-    ) -> list[ModuleSettings]:
+    ) -> list[MODULE_SETTINGS_TYPE]:
         return self.persistence.all(slug)
 
     def get(
@@ -33,14 +36,14 @@ class ModulesRouter:
         slug: str,
         module_type: str,
         name: str,
-    ) -> ModuleSettings:
+    ) -> MODULE_SETTINGS_TYPE:
         return self.persistence.get(slug, module_type, name)
 
     def create(
         self,
         slug: str,
-        payload: Annotated[ModuleSettings, Body(description="Full module settings payload")],
-    ) -> ModuleSettings:
+        payload: Annotated[MODULE_SETTINGS_TYPE, Body(description="Full module settings payload")],
+    ) -> MODULE_SETTINGS_TYPE:
         return self.persistence.create(slug, payload)
 
     def patch(
@@ -48,8 +51,8 @@ class ModulesRouter:
         slug: str,
         module_type: str,
         name: str,
-        patch: Annotated[ModuleSettings, Body(description="Partial module settings payload")],
-    ) -> ModuleSettings:
+        patch: Annotated[MODULE_SETTINGS_TYPE, Body(description="Partial module settings payload")],
+    ) -> MODULE_SETTINGS_TYPE:
         original = self.persistence.get(slug, module_type, name)
         updated = original.model_copy(update=patch.model_dump(exclude_unset=True))
         return self.persistence.replace(slug, module_type, name, updated)
@@ -59,8 +62,8 @@ class ModulesRouter:
         slug: str,
         module_type: str,
         name: str,
-        payload: Annotated[ModuleSettings, Body(description="Full module settings payload")],
-    ) -> ModuleSettings:
+        payload: Annotated[MODULE_SETTINGS_TYPE, Body(description="Full module settings payload")],
+    ) -> MODULE_SETTINGS_TYPE:
         return self.persistence.replace(slug, module_type, name, payload)
 
     def delete(

--- a/src/cofy/management/api/modules.py
+++ b/src/cofy/management/api/modules.py
@@ -84,7 +84,6 @@ class ModulesRouter:
         name: str,
         payload: Annotated[MODULE_SETTINGS_TYPE, Body(description="Full module settings payload")],
     ) -> MODULE_SETTINGS_TYPE:
-        print(payload.model_dump())
         return self.persistence.replace(slug, module_type, name, payload)
 
     def delete(

--- a/src/cofy/management/api/modules.py
+++ b/src/cofy/management/api/modules.py
@@ -3,12 +3,31 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Path
+from pydantic import TypeAdapter
 
 from cofy.api.module import ModuleSettings
+from cofy.modules.billing import BillingModuleSettings  # noqa: F401
+from cofy.modules.tariff import (  # noqa: F401
+    EnergyCostTariffSourceSettings,
+    EntsoeDayAheadTariffSourceSettings,
+    TariffModuleSettings,
+)
+from cofy.modules.timeseries import TimeseriesModuleSettings, TimeseriesSourceSettings  # noqa: F401
 
 from ..persitance.modules import ModulesPersistence
 
 MODULE_SETTINGS_TYPE = ModuleSettings.union_type()
+
+# polymorphic serialisation is not supported by fastapi, see https://github.com/fastapi/fastapi/discussions/15498
+# we monkey patch it in by turning it on by default for all TypeAdapter.dump_json calls, but still allow it to be turned off if needed
+original_dump_json = TypeAdapter.dump_json
+
+
+def monkey_patched_dump_json(self: TypeAdapter, *args, polymorphic_serialization: bool = True, **kwargs):
+    return original_dump_json(self, *args, polymorphic_serialization=polymorphic_serialization, **kwargs)
+
+
+TypeAdapter.dump_json = monkey_patched_dump_json
 
 
 class ModulesRouter:
@@ -30,6 +49,7 @@ class ModulesRouter:
         slug: Annotated[str, Path(description="Community slug, currently one of: foo, bar")],
     ) -> list[MODULE_SETTINGS_TYPE]:
         return self.persistence.all(slug)
+        # return JSONResponse(content=[m.model_dump(polymorphic_serialization=True) for m in self.persistence.all(slug)])
 
     def get(
         self,

--- a/src/cofy/management/api/modules.py
+++ b/src/cofy/management/api/modules.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Path
+
+from cofy.api.module import ModuleSettings
+from cofy.management.persitance.modules import ModulesPersistence
+
+
+class ModulesRouter:
+    def __init__(self, persitance: ModulesPersistence):
+        self.persistence = persitance
+        self.router = APIRouter(prefix="/management/communities/{slug}/modules", tags=["Modules"])
+        self._register_routes()
+
+    def _register_routes(self) -> None:
+        self.router.add_api_route("", self.all, methods=["GET"])
+        self.router.add_api_route("/{module_type}/{name}", self.get, methods=["GET"])
+        self.router.add_api_route("", self.create, methods=["POST"], status_code=201)
+        self.router.add_api_route("/{module_type}/{name}", self.patch, methods=["PATCH"])
+        self.router.add_api_route("/{module_type}/{name}", self.put, methods=["PUT"])
+        self.router.add_api_route("/{module_type}/{name}", self.delete, methods=["DELETE"], status_code=204)
+
+    def all(
+        self,
+        slug: Annotated[str, Path(description="Community slug, currently one of: foo, bar")],
+    ) -> list[ModuleSettings]:
+        return self.persistence.all(slug)
+
+    def get(
+        self,
+        slug: str,
+        module_type: str,
+        name: str,
+    ) -> ModuleSettings:
+        return self.persistence.get(slug, module_type, name)
+
+    def create(
+        self,
+        slug: str,
+        payload: Annotated[ModuleSettings, Body(description="Full module settings payload")],
+    ) -> ModuleSettings:
+        return self.persistence.create(slug, payload)
+
+    def patch(
+        self,
+        slug: str,
+        module_type: str,
+        name: str,
+        patch: Annotated[ModuleSettings, Body(description="Partial module settings payload")],
+    ) -> ModuleSettings:
+        original = self.persistence.get(slug, module_type, name)
+        updated = original.model_copy(update=patch.model_dump(exclude_unset=True))
+        return self.persistence.replace(slug, module_type, name, updated)
+
+    def put(
+        self,
+        slug: str,
+        module_type: str,
+        name: str,
+        payload: Annotated[ModuleSettings, Body(description="Full module settings payload")],
+    ) -> ModuleSettings:
+        return self.persistence.replace(slug, module_type, name, payload)
+
+    def delete(
+        self,
+        slug: str,
+        module_type: str,
+        name: str,
+    ) -> None:
+        self.persistence.delete(slug, module_type, name)
+        return None

--- a/src/cofy/management/api/modules.py
+++ b/src/cofy/management/api/modules.py
@@ -84,6 +84,7 @@ class ModulesRouter:
         name: str,
         payload: Annotated[MODULE_SETTINGS_TYPE, Body(description="Full module settings payload")],
     ) -> MODULE_SETTINGS_TYPE:
+        print(payload.model_dump())
         return self.persistence.replace(slug, module_type, name, payload)
 
     def delete(

--- a/src/cofy/management/errors.py
+++ b/src/cofy/management/errors.py
@@ -1,0 +1,23 @@
+class ResourceNotFoundError(Exception):
+    pass
+
+
+class ResourceAlreadyExistsError(Exception):
+    pass
+
+
+def add_exception_handlers(app):
+    from fastapi import Request
+    from fastapi.responses import JSONResponse
+
+    @app.exception_handler(ResourceNotFoundError)
+    async def handle_not_found_error(request: Request, exc: ResourceNotFoundError):
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    @app.exception_handler(ResourceAlreadyExistsError)
+    async def handle_conflict_error(request: Request, exc: ResourceAlreadyExistsError):
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+
+    @app.exception_handler(ValueError)
+    async def handle_validation_error(request: Request, exc: ValueError):
+        return JSONResponse(status_code=422, content={"detail": str(exc)})

--- a/src/cofy/management/main.py
+++ b/src/cofy/management/main.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+
+from .api.modules import ModulesRouter
+from .errors import add_exception_handlers
+from .persitance.file.modules import FileModulesPersistence
+
+app = FastAPI(title="Cofy Management API", version="0.1.0", description="Management API for Cofy")
+add_exception_handlers(app)
+
+app.include_router(ModulesRouter(FileModulesPersistence()).router)

--- a/src/cofy/management/persitance/__init__.py
+++ b/src/cofy/management/persitance/__init__.py
@@ -1,0 +1,3 @@
+from .modules import ModulesPersistence
+
+__all__ = ["ModulesPersistence"]

--- a/src/cofy/management/persitance/file/__init__.py
+++ b/src/cofy/management/persitance/file/__init__.py
@@ -1,0 +1,4 @@
+from .base import FilePersistence
+from .modules import FileModulesPersistence
+
+__all__ = ["FilePersistence", "FileModulesPersistence"]

--- a/src/cofy/management/persitance/file/base.py
+++ b/src/cofy/management/persitance/file/base.py
@@ -33,4 +33,8 @@ class FilePersistence:
     def _save_community_config(self, slug: str, config: CofyAPISettings) -> None:
         path = self._community_path(slug)
         with path.open("w", encoding="utf-8") as handle:
-            yaml.safe_dump(config.model_dump(exclude_none=True), handle, sort_keys=True)
+            yaml.safe_dump(
+                config.model_dump(exclude_none=True, polymorphic_serialization=True, round_trip=True),
+                handle,
+                sort_keys=True,
+            )

--- a/src/cofy/management/persitance/file/base.py
+++ b/src/cofy/management/persitance/file/base.py
@@ -1,0 +1,36 @@
+from importlib import resources
+from pathlib import Path
+
+import yaml
+
+from cofy.api.cofy_api import CofyAPISettings
+
+from ...errors import ResourceNotFoundError
+
+DEFAULT_BASE_PATH = Path(str(resources.files("cofy.management.persitance.file") / "data"))
+
+
+class FilePersistence:
+    def __init__(self, base_path: Path = DEFAULT_BASE_PATH):
+        self.base_path = base_path
+
+    def _community_path(self, slug: str) -> Path:
+        return self.base_path / f"{slug}.yaml"
+
+    def _get_community_config(self, slug: str) -> CofyAPISettings:
+        path = self._community_path(slug)
+        if not path.exists():
+            raise ResourceNotFoundError(f"Community {slug!r} not found")
+
+        with path.open("r", encoding="utf-8") as handle:
+            loaded = yaml.safe_load(handle) or {}
+
+        if not isinstance(loaded, dict):
+            raise ValueError(f"Community config at {path} must be a YAML mapping")
+
+        return CofyAPISettings.model_validate(loaded)
+
+    def _save_community_config(self, slug: str, config: CofyAPISettings) -> None:
+        path = self._community_path(slug)
+        with path.open("w", encoding="utf-8") as handle:
+            yaml.safe_dump(config.model_dump(exclude_none=True), handle, sort_keys=True)

--- a/src/cofy/management/persitance/file/data/bar.yaml
+++ b/src/cofy/management/persitance/file/data/bar.yaml
@@ -1,0 +1,4 @@
+type: cofy-api
+title: bar
+modules:
+  - type: billing

--- a/src/cofy/management/persitance/file/data/foo.yaml
+++ b/src/cofy/management/persitance/file/data/foo.yaml
@@ -1,0 +1,49 @@
+{
+        "type": "cofy_api",
+        "title": "foo",
+        "debug_mode": True,
+        "auth": {
+            "type": "token",
+            "tokens": {
+                "foo": {
+                    "name": "Demo User",
+                }
+            },
+        },
+        "modules": [
+            {
+                "type": "tariff",
+                "name": "entsoe",
+                "source": {
+                    "type": "entsoe_day_ahead",
+                    "api_key": "***",
+                },
+            },
+            {
+                "type": "tariff",
+                "name": "kiwatt",
+                "source": {
+                    "type": "entsoe_day_ahead",
+                    "country_code": "NL",
+                    "api_key": "***",
+                },
+                "formats": [
+                    {
+                        "type": "kiwatt",
+                    }
+                ],
+            },
+            {
+                "type": "tariff",
+                "name": "dynamic",
+                "description": "Our dynamic tariff tracking the Belpex.",
+                "source": {
+                    "type": "energy_cost",
+                    "tariff": {"consumption": {"constant_cost": 1}, "start": "2026-01-01:00:00:00Z"},
+                },
+            },
+            {
+                "type": "billing",
+            },
+        ],
+    }

--- a/src/cofy/management/persitance/file/data/foo.yaml
+++ b/src/cofy/management/persitance/file/data/foo.yaml
@@ -28,7 +28,7 @@ modules:
       consumption:
         total:
           capacity_based: false
-          constant_cost: 1.0
+          constant_cost: 2.0
           kind: index
           variable_costs: []
       fixed: {}

--- a/src/cofy/management/persitance/file/data/foo.yaml
+++ b/src/cofy/management/persitance/file/data/foo.yaml
@@ -1,49 +1,42 @@
-{
-        "type": "cofy_api",
-        "title": "foo",
-        "debug_mode": True,
-        "auth": {
-            "type": "token",
-            "tokens": {
-                "foo": {
-                    "name": "Demo User",
-                }
-            },
-        },
-        "modules": [
-            {
-                "type": "tariff",
-                "name": "entsoe",
-                "source": {
-                    "type": "entsoe_day_ahead",
-                    "api_key": "***",
-                },
-            },
-            {
-                "type": "tariff",
-                "name": "kiwatt",
-                "source": {
-                    "type": "entsoe_day_ahead",
-                    "country_code": "NL",
-                    "api_key": "***",
-                },
-                "formats": [
-                    {
-                        "type": "kiwatt",
-                    }
-                ],
-            },
-            {
-                "type": "tariff",
-                "name": "dynamic",
-                "description": "Our dynamic tariff tracking the Belpex.",
-                "source": {
-                    "type": "energy_cost",
-                    "tariff": [{"consumption": {"constant_cost": 1}, "start": "2026-01-01T00:00:00Z"}],
-                },
-            },
-            {
-                "type": "billing",
-            },
-        ],
-    }
+auth:
+  tokens:
+    foo:
+      name: Demo User
+  type: token
+debug_mode: true
+description: Modular cloud API for energy data
+modules:
+- name: entsoe
+  source:
+    api_key: '***'
+    type: entsoe_day_ahead
+  type: tariff
+- formats:
+  - source: Cofy-API-Demo
+    type: kiwatt
+  name: kiwatt
+  source:
+    api_key: '***'
+    country_code: NL
+    type: entsoe_day_ahead
+  type: tariff
+- description: Our dynamic tariff tracking the Belpex.
+  name: dynamic
+  source:
+    tariff:
+    - capacity: {}
+      consumption:
+        total:
+          capacity_based: false
+          constant_cost: 1.0
+          kind: index
+          variable_costs: []
+      fixed: {}
+      injection: {}
+      start: 2026-01-01 00:00:00+00:00
+    type: energy_cost
+  type: tariff
+- name: default
+  type: billing
+title: foo
+type: cofy_api

--- a/src/cofy/management/persitance/file/data/foo.yaml
+++ b/src/cofy/management/persitance/file/data/foo.yaml
@@ -39,7 +39,7 @@
                 "description": "Our dynamic tariff tracking the Belpex.",
                 "source": {
                     "type": "energy_cost",
-                    "tariff": {"consumption": {"constant_cost": 1}, "start": "2026-01-01:00:00:00Z"},
+                    "tariff": [{"consumption": {"constant_cost": 1}, "start": "2026-01-01T00:00:00Z"}],
                 },
             },
             {

--- a/src/cofy/management/persitance/file/modules.py
+++ b/src/cofy/management/persitance/file/modules.py
@@ -17,7 +17,7 @@ class FileModulesPersistence(FilePersistence, ModulesPersistence):
 
     def create(self, slug: str, module: ModuleSettings) -> ModuleSettings:
         config = self._get_community_config(slug)
-        if any((module.type, module.name) == (module.type, module.name) for module in config.modules):
+        if any((module.type, module.name) == (m.type, m.name) for m in config.modules):
             raise ValueError(f"Module {module.type}:{module.name} already exists")
         config.modules = config.modules + [module]
         self._save_community_config(slug, config)
@@ -25,8 +25,8 @@ class FileModulesPersistence(FilePersistence, ModulesPersistence):
 
     def replace(self, slug: str, module_type: str, name: str, module: ModuleSettings) -> ModuleSettings:
         config = self._get_community_config(slug)
-        for i, module in enumerate(config.modules):
-            if (module.type, module.name) == (module_type, name):
+        for i, m in enumerate(config.modules):
+            if (m.type, m.name) == (module_type, name):
                 config.modules[i] = module
                 self._save_community_config(slug, config)
                 return module

--- a/src/cofy/management/persitance/file/modules.py
+++ b/src/cofy/management/persitance/file/modules.py
@@ -1,6 +1,6 @@
 from cofy.api.module import ModuleSettings
 
-from ...errors import ResourceNotFoundError
+from ...errors import ResourceAlreadyExistsError, ResourceNotFoundError
 from ..modules import ModulesPersistence
 from .base import FilePersistence
 
@@ -18,7 +18,7 @@ class FileModulesPersistence(FilePersistence, ModulesPersistence):
     def create(self, slug: str, module: ModuleSettings) -> ModuleSettings:
         config = self._get_community_config(slug)
         if any((module.type, module.name) == (m.type, m.name) for m in config.modules):
-            raise ValueError(f"Module {module.type}:{module.name} already exists")
+            raise ResourceAlreadyExistsError(f"Module {module.type}:{module.name} already exists")
         config.modules = config.modules + [module]
         self._save_community_config(slug, config)
         return module

--- a/src/cofy/management/persitance/file/modules.py
+++ b/src/cofy/management/persitance/file/modules.py
@@ -1,0 +1,42 @@
+from cofy.api.module import ModuleSettings
+
+from ...errors import ResourceNotFoundError
+from ..modules import ModulesPersistence
+from .base import FilePersistence
+
+
+class FileModulesPersistence(FilePersistence, ModulesPersistence):
+    def all(self, slug: str) -> list[ModuleSettings]:
+        return self._get_community_config(slug).modules
+
+    def get(self, slug: str, module_type: str, name: str) -> ModuleSettings:
+        for module in self._get_community_config(slug).modules:
+            if (module.type, module.name) == (module_type, name):
+                return module
+        raise ResourceNotFoundError(f"Module {module_type}:{name} not found")
+
+    def create(self, slug: str, module: ModuleSettings) -> ModuleSettings:
+        config = self._get_community_config(slug)
+        if any((module.type, module.name) == (module.type, module.name) for module in config.modules):
+            raise ValueError(f"Module {module.type}:{module.name} already exists")
+        config.modules = config.modules + [module]
+        self._save_community_config(slug, config)
+        return module
+
+    def replace(self, slug: str, module_type: str, name: str, module: ModuleSettings) -> ModuleSettings:
+        config = self._get_community_config(slug)
+        for i, module in enumerate(config.modules):
+            if (module.type, module.name) == (module_type, name):
+                config.modules[i] = module
+                self._save_community_config(slug, config)
+                return module
+        raise ResourceNotFoundError(f"Module {module_type}:{name} not found")
+
+    def delete(self, slug: str, module_type: str, name: str) -> None:
+        config = self._get_community_config(slug)
+        for i, module in enumerate(config.modules):
+            if (module.type, module.name) == (module_type, name):
+                del config.modules[i]
+                self._save_community_config(slug, config)
+                return
+        raise ResourceNotFoundError(f"Module {module_type}:{name} not found")

--- a/src/cofy/management/persitance/modules.py
+++ b/src/cofy/management/persitance/modules.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from cofy.api.module import ModuleSettings
+
+
+class ModulesPersistence(ABC):
+    @abstractmethod
+    def all(self, slug: str) -> list[ModuleSettings]:
+        """List all modules for a community."""
+
+    @abstractmethod
+    def get(self, slug: str, module_type: str, name: str) -> ModuleSettings:
+        """Get one module by community slug, type and name."""
+
+    @abstractmethod
+    def create(self, slug: str, module: ModuleSettings) -> ModuleSettings:
+        """Create one module for a community."""
+
+    @abstractmethod
+    def replace(self, slug: str, module_type: str, name: str, module: ModuleSettings) -> ModuleSettings:
+        """Replace one module for a community."""
+
+    @abstractmethod
+    def delete(self, slug: str, module_type: str, name: str) -> None:
+        """Delete one module for a community."""

--- a/src/cofy/modules/production/sources/energyID_production.py
+++ b/src/cofy/modules/production/sources/energyID_production.py
@@ -4,14 +4,14 @@ import datetime as dt
 import polars as pl
 import requests
 from isodate import strftime
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel
 
 from cofy.modules.timeseries import ISODuration, Timeseries, TimeseriesSource, TimeseriesSourceSettings
 
 
 class EnergyIDProductionSettings(TimeseriesSourceSettings):
     type: str = "energyid_production"
-    api_key: SecretStr
+    api_key: str
     record_id: str
 
 

--- a/src/cofy/modules/tariff/sources/entsoe_day_ahead.py
+++ b/src/cofy/modules/tariff/sources/entsoe_day_ahead.py
@@ -6,14 +6,14 @@ import pandas as pd
 from entsoe import EntsoePandasClient
 from entsoe.exceptions import NoMatchingDataError
 from fastapi.params import Query
-from pydantic import Field, SecretStr
+from pydantic import Field
 
 from cofy.modules.timeseries import ISODuration, Timeseries, TimeseriesSource, TimeseriesSourceSettings
 
 
 class EntsoeDayAheadTariffSourceSettings(TimeseriesSourceSettings):
     type: str = "entsoe_day_ahead"
-    api_key: SecretStr
+    api_key: str
     country_code: str | None = None
 
 

--- a/tests/cofy/api/from_settings_mixin_test.py
+++ b/tests/cofy/api/from_settings_mixin_test.py
@@ -1,5 +1,4 @@
 import pytest
-from pydantic import SecretStr
 
 from cofy.api.from_settings_mixin import BaseSettingsModel, FromSettingsMixin
 
@@ -145,21 +144,6 @@ def test_recursion_in_inner_settings():
     assert b.foo == 10
     assert b.a.foo == 20
     assert b.a.a.foo == 30
-
-
-def test_secret_values_are_unwrapped():
-    class SecretSettings(BaseSettingsModel):
-        type: str = "secret"
-        token: SecretStr
-
-    class SecretConsumer(FromSettingsMixin, settings=SecretSettings):
-        def __init__(self, token: str):
-            self.token = token
-
-    consumer = SecretConsumer.create({"type": "secret", "token": "super-secret"})
-    assert isinstance(consumer, SecretConsumer)
-    assert isinstance(consumer.token, str)
-    assert consumer.token == "super-secret"
 
 
 def test_settings_dispatch_accepts_existing_settings_instance():

--- a/tests/cofy/api/from_settings_mixin_test.py
+++ b/tests/cofy/api/from_settings_mixin_test.py
@@ -1,6 +1,35 @@
+from __future__ import annotations
+
 import pytest
 
 from cofy.api.from_settings_mixin import BaseSettingsModel, FromSettingsMixin
+
+
+def test_union_type_skips_unregistered_nested_settings():
+    """A BaseSettingsModel subclass used as a field type but never registered with a
+    FromSettingsMixin is left as-is in the response schema (not expanded into a union)."""
+
+    class MetadataSettings(BaseSettingsModel):
+        type: str = "metadata"
+        label: str
+
+    # MetadataSettings intentionally has no FromSettingsMixin subclass registered.
+
+    class WidgetSettings(BaseSettingsModel):
+        type: str = "widget"
+        meta: MetadataSettings
+
+    class Widget(FromSettingsMixin, settings=WidgetSettings):
+        def __init__(self, meta: MetadataSettings):
+            self.meta = meta
+
+    union_type = WidgetSettings.union_type()
+
+    from pydantic import TypeAdapter
+
+    ta = TypeAdapter(union_type)
+    result = ta.validate_python({"type": "widget", "meta": {"type": "metadata", "label": "hello"}})
+    assert result.meta.label == "hello"
 
 
 def test_classes_register_as_tree():
@@ -390,3 +419,106 @@ def test_union_type_returns_correct_union():
     assert data["a"]["type"] == "b"
     assert data["a"]["value"] == 10
     assert data["a"]["extra"] == "hello"
+
+
+def test_union_type_expands_list_fields():
+    """union_type() recursively expands list[SettingsType] fields so response includes subtype-specific fields."""
+
+    class PartSettings(BaseSettingsModel):
+        type: str = "part"
+        weight: int
+
+    class Part(FromSettingsMixin, settings=PartSettings):
+        def __init__(self, weight: int):
+            self.weight = weight
+
+    class HeavyPartSettings(PartSettings):
+        type: str = "heavy_part"
+        material: str
+
+    class HeavyPart(Part, settings=HeavyPartSettings):
+        def __init__(self, weight: int, material: str):
+            super().__init__(weight)
+            self.material = material
+
+    class CrateSettings(BaseSettingsModel):
+        type: str = "crate"
+        parts: list[PartSettings]
+        named_parts: dict[str, PartSettings] = {}
+        labels: list[str] = []
+
+    class Crate(FromSettingsMixin, settings=CrateSettings):
+        def __init__(self, parts: list[Part], named_parts: dict[str, Part], labels: list[str]):
+            self.parts = parts
+            self.named_parts = named_parts
+            self.labels = labels
+
+    union_type = CrateSettings.union_type()
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+
+    @app.get("/crate", response_model=union_type)
+    def endpoint():
+        return {
+            "type": "crate",
+            "parts": [{"type": "heavy_part", "weight": 10, "material": "steel"}],
+            "named_parts": {"main": {"type": "heavy_part", "weight": 5, "material": "iron"}},
+            "labels": ["fragile"],
+        }
+
+    client = TestClient(app)
+    response = client.get("/crate")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["parts"][0]["material"] == "steel"
+    assert data["named_parts"]["main"]["material"] == "iron"
+    assert data["labels"] == ["fragile"]
+
+
+def test_union_type_expands_optional_fields():
+    """union_type() recursively expands Optional[SettingsType] fields so response includes subtype-specific fields."""
+
+    class EngineSettings(BaseSettingsModel):
+        type: str = "engine"
+        power: int
+
+    class Engine(FromSettingsMixin, settings=EngineSettings):
+        def __init__(self, power: int):
+            self.power = power
+
+    class TurboEngineSettings(EngineSettings):
+        type: str = "turbo_engine"
+        boost: float
+
+    class TurboEngine(Engine, settings=TurboEngineSettings):
+        def __init__(self, power: int, boost: float):
+            super().__init__(power)
+            self.boost = boost
+
+    class CarSettings(BaseSettingsModel):
+        type: str = "car"
+        engine: EngineSettings | None = None
+
+    class Car(FromSettingsMixin, settings=CarSettings):
+        def __init__(self, engine: Engine | None = None):
+            self.engine = engine
+
+    union_type = CarSettings.union_type()
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+
+    @app.get("/car", response_model=union_type)
+    def endpoint():
+        return {"type": "car", "engine": {"type": "turbo_engine", "power": 200, "boost": 1.5}}
+
+    client = TestClient(app)
+    response = client.get("/car")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["engine"]["boost"] == 1.5

--- a/tests/cofy/api/from_settings_mixin_test.py
+++ b/tests/cofy/api/from_settings_mixin_test.py
@@ -297,3 +297,112 @@ def test_rejects_duplicate_type_registration():
 
         class DuplicateA(A, settings=DuplicateASettings):
             pass
+
+
+def test_settings_classes_correctly_validate_subclasses():
+    class ASettings(BaseSettingsModel):
+        type: str = "a"
+        value: int
+
+    class A(FromSettingsMixin, settings=ASettings):
+        def __init__(self, value: int):
+            self.value = value
+
+    class BSettings(ASettings):
+        type: str = "b"
+        extra: str
+
+    class B(A, settings=BSettings):
+        def __init__(self, value: int, extra: str):
+            super().__init__(value)
+            self.extra = extra
+
+    b = ASettings.model_validate({"type": "b", "value": 10, "extra": "hello"})
+    assert isinstance(b, BSettings)
+    assert b.value == 10
+    assert b.extra == "hello"
+
+
+def test_settings_classes_correctly_validate_param_subclasses():
+    class ASettings(BaseSettingsModel):
+        type: str = "a"
+        value: int
+
+    class A(FromSettingsMixin, settings=ASettings):
+        def __init__(self, value: int):
+            self.value = value
+
+    class BSettings(ASettings):
+        type: str = "b"
+        extra: str
+
+    class B(A, settings=BSettings):
+        def __init__(self, value: int, extra: str):
+            super().__init__(value)
+            self.extra = extra
+
+    class CSettings(BaseSettingsModel):
+        type: str = "c"
+        a: ASettings
+
+    class C(FromSettingsMixin, settings=CSettings):
+        def __init__(self, a: A):
+            self.a = a
+
+    c = CSettings.model_validate({"type": "c", "a": {"type": "b", "value": 10, "extra": "hello"}})
+    assert isinstance(c, CSettings)
+    assert isinstance(c.a, BSettings)
+    assert c.a.value == 10
+    assert c.a.extra == "hello"
+
+    c = CSettings.model_validate({"type": "c", "a": {"type": "a", "value": 5}})
+    assert isinstance(c, CSettings)
+    assert isinstance(c.a, ASettings)
+    assert c.a.value == 5
+
+
+def test_union_type_returns_correct_union():
+    class ASettings(BaseSettingsModel):
+        type: str = "a"
+        value: int
+
+    class A(FromSettingsMixin, settings=ASettings):
+        def __init__(self, value: int):
+            self.value = value
+
+    class BSettings(ASettings):
+        type: str = "b"
+        extra: str
+
+    class B(A, settings=BSettings):
+        def __init__(self, value: int, extra: str):
+            super().__init__(value)
+            self.extra = extra
+
+    class CSettings(BaseSettingsModel):
+        type: str = "c"
+        a: ASettings
+
+    class C(FromSettingsMixin, settings=CSettings):
+        def __init__(self, a: A):
+            self.a = a
+
+    union_type = CSettings.union_type()
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+
+    @app.get("/test", response_model=union_type)
+    def test_endpoint():
+        return {"type": "c", "a": {"type": "b", "value": 10, "extra": "hello"}}
+
+    client = TestClient(app)
+    response = client.get("/test")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["type"] == "c"
+    assert data["a"]["type"] == "b"
+    assert data["a"]["value"] == 10
+    assert data["a"]["extra"] == "hello"

--- a/tests/cofy/dependency_boundary_test.py
+++ b/tests/cofy/dependency_boundary_test.py
@@ -27,6 +27,7 @@ import pytest
 # PyPI names whose import name differs from the normalised form.
 IMPORT_OVERRIDES: dict[str, set[str]] = {
     "entsoe-py": {"entsoe"},
+    "PyYAML": {"yaml"},
 }
 
 # Extra name → source path prefix(es) it "owns" (relative to src/cofy/).
@@ -38,6 +39,7 @@ EXTRA_ZONES: dict[str, set[str]] = {
     "members": {"modules/members/"},
     "directive": {"modules/directive/"},
     "debug": {"api/debug_"},
+    "management": {"management/"},
 }
 
 # Zones that are always accessible (no extra required).

--- a/tests/cofy/management/api/modules_test.py
+++ b/tests/cofy/management/api/modules_test.py
@@ -1,0 +1,250 @@
+"""Integration tests for ModulesRouter with FileModulesPersistence.
+
+Each test creates a fresh temporary directory with a minimal community YAML file,
+wires up the full router, and exercises the HTTP API via TestClient.
+File-level assertions are used where a mutation should have persisted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cofy.management.api.modules import ModulesRouter
+from cofy.management.errors import add_exception_handlers
+from cofy.management.persitance.file.modules import FileModulesPersistence
+
+# ── fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def tmp_data(tmp_path: Path):
+    """Return a temp directory pre-populated with a single community 'test'."""
+    community = {
+        "type": "cofy_api",
+        "modules": [
+            {
+                "type": "billing",
+                "name": "default",
+            },
+            {
+                "type": "tariff",
+                "name": "spot",
+                "source": {
+                    "type": "entsoe_day_ahead",
+                    "api_key": "secret-key",
+                    "country_code": "BE",
+                },
+            },
+        ],
+    }
+    (tmp_path / "test.yaml").write_text(yaml.safe_dump(community))
+    return tmp_path
+
+
+@pytest.fixture()
+def client(tmp_data: Path) -> TestClient:
+    """Return a TestClient wired to the full router + file persistence in tmp_data."""
+    app = FastAPI()
+    add_exception_handlers(app)
+    app.include_router(ModulesRouter(FileModulesPersistence(tmp_data)).router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ── helper ────────────────────────────────────────────────────────────────
+
+
+def _read_modules(tmp_data: Path) -> list[dict]:
+    data = yaml.safe_load((tmp_data / "test.yaml").read_text())
+    return data.get("modules", [])
+
+
+# ── GET /all ──────────────────────────────────────────────────────────────
+
+
+def test_all_returns_existing_modules(client: TestClient):
+    r = client.get("/management/communities/test/modules")
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data) == 2
+    types = {m["type"] for m in data}
+    assert types == {"billing", "tariff"}
+
+
+def test_all_includes_subtype_fields(client: TestClient):
+    """Source-specific fields (api_key, country_code) must appear in the response."""
+    r = client.get("/management/communities/test/modules")
+    assert r.status_code == 200
+    tariff = next(m for m in r.json() if m["type"] == "tariff")
+    assert tariff["source"]["api_key"] == "secret-key"
+    assert tariff["source"]["country_code"] == "BE"
+
+
+def test_all_unknown_community_returns_404(client: TestClient):
+    r = client.get("/management/communities/unknown/modules")
+    assert r.status_code == 404
+
+
+# ── GET /{module_type}/{name} ─────────────────────────────────────────────
+
+
+def test_get_existing_module(client: TestClient):
+    r = client.get("/management/communities/test/modules/billing/default")
+    assert r.status_code == 200
+    assert r.json()["type"] == "billing"
+    assert r.json()["name"] == "default"
+
+
+def test_get_preserves_source_fields(client: TestClient):
+    r = client.get("/management/communities/test/modules/tariff/spot")
+    assert r.status_code == 200
+    source = r.json()["source"]
+    assert source["type"] == "entsoe_day_ahead"
+    assert source["api_key"] == "secret-key"
+
+
+def test_get_unknown_module_returns_404(client: TestClient):
+    r = client.get("/management/communities/test/modules/tariff/missing")
+    assert r.status_code == 404
+
+
+# ── POST / (create) ───────────────────────────────────────────────────────
+
+
+def test_create_new_module(client: TestClient, tmp_data: Path):
+    payload = {"type": "billing", "name": "extra"}
+    r = client.post("/management/communities/test/modules", json=payload)
+    assert r.status_code == 201
+    assert r.json()["name"] == "extra"
+
+    # Verify the file was updated
+    saved = _read_modules(tmp_data)
+    assert any(m["type"] == "billing" and m["name"] == "extra" for m in saved)
+
+
+def test_create_duplicate_module_returns_409(client: TestClient):
+    payload = {"type": "billing", "name": "default"}
+    r = client.post("/management/communities/test/modules", json=payload)
+    assert r.status_code == 409
+    assert "already exists" in r.json()["detail"]
+
+
+def test_resource_already_exists_handler_returns_409(tmp_data: Path):
+    """ResourceAlreadyExistsError raised by persistence is mapped to 409."""
+    from unittest.mock import MagicMock
+
+    mock_persistence = MagicMock()
+    from cofy.management.errors import ResourceAlreadyExistsError
+
+    mock_persistence.create.side_effect = ResourceAlreadyExistsError("already exists")
+
+    app = FastAPI()
+    add_exception_handlers(app)
+    app.include_router(ModulesRouter(mock_persistence).router)
+    c = TestClient(app, raise_server_exceptions=False)
+
+    r = c.post("/management/communities/test/modules", json={"type": "billing", "name": "default"})
+    assert r.status_code == 409
+    assert "already exists" in r.json()["detail"]
+
+
+def test_community_with_invalid_yaml_returns_error(tmp_data: Path):
+    """A community YAML that is not a mapping raises a 500 error (ValueError from base)."""
+    (tmp_data / "bad.yaml").write_text("- just\n- a\n- list\n")
+
+    app = FastAPI()
+    add_exception_handlers(app)
+    app.include_router(ModulesRouter(FileModulesPersistence(tmp_data)).router)
+    bad_client = TestClient(app, raise_server_exceptions=False)
+
+    r = bad_client.get("/management/communities/bad/modules")
+    assert r.status_code == 422
+
+
+def test_create_persists_source_settings(client: TestClient, tmp_data: Path):
+    payload = {
+        "type": "tariff",
+        "name": "new_spot",
+        "source": {"type": "entsoe_day_ahead", "api_key": "new-key", "country_code": "NL"},
+    }
+    r = client.post("/management/communities/test/modules", json=payload)
+    assert r.status_code == 201
+
+    saved = _read_modules(tmp_data)
+    new_module = next((m for m in saved if m["name"] == "new_spot"), None)
+    assert new_module is not None
+    assert new_module["source"]["api_key"] == "new-key"
+    assert new_module["source"]["country_code"] == "NL"
+
+
+# ── PUT /{module_type}/{name} (replace) ───────────────────────────────────
+
+
+def test_put_replaces_module(client: TestClient, tmp_data: Path):
+    payload = {
+        "type": "tariff",
+        "name": "spot",
+        "source": {"type": "entsoe_day_ahead", "api_key": "replaced-key", "country_code": "DE"},
+    }
+    r = client.put("/management/communities/test/modules/tariff/spot", json=payload)
+    assert r.status_code == 200
+    assert r.json()["source"]["api_key"] == "replaced-key"
+
+    # Verify file reflects the change
+    saved = _read_modules(tmp_data)
+    spot = next(m for m in saved if m["name"] == "spot")
+    assert spot["source"]["api_key"] == "replaced-key"
+    assert spot["source"]["country_code"] == "DE"
+
+
+def test_put_unknown_module_returns_404(client: TestClient):
+    payload = {"type": "billing", "name": "ghost"}
+    r = client.put("/management/communities/test/modules/billing/ghost", json=payload)
+    assert r.status_code == 404
+
+
+# ── PATCH /{module_type}/{name} (partial update) ──────────────────────────
+
+
+def test_patch_updates_description(client: TestClient, tmp_data: Path):
+    patch = {"type": "billing", "name": "default", "description": "Updated desc"}
+    r = client.patch("/management/communities/test/modules/billing/default", json=patch)
+    assert r.status_code == 200
+    assert r.json()["description"] == "Updated desc"
+
+    saved = _read_modules(tmp_data)
+    billing = next(m for m in saved if m["name"] == "default")
+    assert billing.get("description") == "Updated desc"
+
+
+def test_patch_unknown_module_returns_404(client: TestClient):
+    patch = {"type": "billing", "name": "ghost", "description": "x"}
+    r = client.patch("/management/communities/test/modules/billing/ghost", json=patch)
+    assert r.status_code == 404
+
+
+# ── DELETE /{module_type}/{name} ──────────────────────────────────────────
+
+
+def test_delete_removes_module(client: TestClient, tmp_data: Path):
+    r = client.delete("/management/communities/test/modules/billing/default")
+    assert r.status_code == 204
+
+    saved = _read_modules(tmp_data)
+    assert not any(m["type"] == "billing" and m["name"] == "default" for m in saved)
+
+
+def test_delete_unknown_module_returns_404(client: TestClient):
+    r = client.delete("/management/communities/test/modules/billing/ghost")
+    assert r.status_code == 404
+
+
+def test_delete_does_not_affect_other_modules(client: TestClient, tmp_data: Path):
+    client.delete("/management/communities/test/modules/billing/default")
+
+    saved = _read_modules(tmp_data)
+    assert any(m["type"] == "tariff" and m["name"] == "spot" for m in saved)

--- a/uv.lock
+++ b/uv.lock
@@ -182,6 +182,17 @@ directive = [
     { name = "isodate" },
     { name = "narwhals" },
 ]
+management = [
+    { name = "energy-cost" },
+    { name = "entsoe-py" },
+    { name = "isodate" },
+    { name = "narwhals" },
+    { name = "pandas" },
+    { name = "polars" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "yappi" },
+]
 members = [
     { name = "energy-cost" },
 ]
@@ -221,6 +232,7 @@ requires-dist = [
     { name = "cofy-api", extras = ["timeseries"], marker = "extra == 'production'" },
     { name = "cofy-api", extras = ["timeseries"], marker = "extra == 'tariff'" },
     { name = "cofy-api", extras = ["timeseries", "tariff", "members", "production", "directive", "billing", "debug"], marker = "extra == 'all'" },
+    { name = "cofy-api", extras = ["timeseries", "tariff", "members", "production", "directive", "billing", "debug"], marker = "extra == 'management'" },
     { name = "energy-cost", marker = "extra == 'billing'", specifier = ">=0.7.0" },
     { name = "energy-cost", marker = "extra == 'members'", specifier = ">=0.7.0" },
     { name = "energy-cost", marker = "extra == 'tariff'", specifier = ">=0.7.0" },
@@ -233,11 +245,12 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'tariff'", specifier = ">=3.0.0" },
     { name = "polars", marker = "extra == 'production'", specifier = ">=1.38.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pyyaml", marker = "extra == 'management'", specifier = ">=6.0.0" },
     { name = "requests", marker = "extra == 'production'", specifier = ">=2.32.0" },
     { name = "starlette", specifier = ">=0.41.0" },
     { name = "yappi", marker = "extra == 'debug'", specifier = ">=1.7.6" },
 ]
-provides-extras = ["timeseries", "tariff", "billing", "production", "members", "directive", "debug", "all"]
+provides-extras = ["timeseries", "tariff", "billing", "production", "members", "directive", "debug", "management", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This pull request adds a management API for COFY-cloud settings documents.

The API is currently limited to CRUD modules. 

The settings are stored in files. This is write with an abstract persistence layer, sow e can easily replace this by a DB in the future.
For now the file works smoothly as we can easily launch a cofy cloud from the same settings file.

Future work:
- auto spin up and update a cofy cloud based on managed settings
- add a frontend for this API
- Add authentication to this API
- Update Readme and docs to explain management API.


part of: #184